### PR TITLE
Add 1.19.2 to 1.19.1 compatibility version (#3)

### DIFF
--- a/v1.19.1/src/main/java/net/pinger/disguise/packet/v1_19_1/PacketProviderImpl.java
+++ b/v1.19.1/src/main/java/net/pinger/disguise/packet/v1_19_1/PacketProviderImpl.java
@@ -18,7 +18,7 @@ import org.bukkit.plugin.Plugin;
 
 import javax.annotation.Nonnull;
 
-@PacketHandler(version = "1.19.1")
+@PacketHandler(version = "1.19.1", compatibility = "1.19.2")
 public class PacketProviderImpl implements PacketProvider {
 
     private final Plugin plugin;


### PR DESCRIPTION
Added 1.19.2 support without creating a new module. This is done by adding a compatibility version to the 1.19.1 after assuring that the two have the same obfuscated methods (#3).

